### PR TITLE
로그인, 로그아웃 로직 수정

### DIFF
--- a/src/main/java/com/nhnacademy/frontserver/auth/client/AuthClient.java
+++ b/src/main/java/com/nhnacademy/frontserver/auth/client/AuthClient.java
@@ -17,7 +17,7 @@ public interface AuthClient {
     TokenResponse login(@RequestBody LoginRequest loginRequest);
 
     @PostMapping("/api/auth/logout")
-    void logout(@RequestHeader("Authorization") String accessToken);;
+    void logout();
 
     @PostMapping("/api/auth/reissue")
     TokenResponse reissue(@RequestHeader("X-Refresh-Token") String refreshToken);

--- a/src/main/java/com/nhnacademy/frontserver/auth/config/FeignClientConfig.java
+++ b/src/main/java/com/nhnacademy/frontserver/auth/config/FeignClientConfig.java
@@ -13,10 +13,13 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @Configuration
 public class FeignClientConfig {
 
-    // 브라우저로 부터 받은 쿠키 꺼내서 헤더로 변경
     @Bean
     public RequestInterceptor requestInterceptor() {
         return template -> {
+            if (template.url().contains("/reissue")) {
+                return;
+            }
+
             ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
 
             if (attributes != null) {

--- a/src/main/java/com/nhnacademy/frontserver/auth/controller/AuthController.java
+++ b/src/main/java/com/nhnacademy/frontserver/auth/controller/AuthController.java
@@ -52,8 +52,9 @@ public class AuthController {
         // Auth Service에 로그아웃 요청 (Redis Blacklist 등록)
         // FeignInterceptor가 현재 쿠키의 AccessToken을 헤더에 담아 보냄
         try {
-            authClient.logout(response.getHeader("Authorization"));
+            authClient.logout();
         } catch (Exception e) {
+            log.warn("로그아웃 처리 중 오류 (무시됨): {}", e.getMessage());
         }
         response.addHeader(HttpHeaders.SET_COOKIE, CookieUtils.deleteCookie("accessToken").toString());
         response.addHeader(HttpHeaders.SET_COOKIE, CookieUtils.deleteCookie("refreshToken").toString());

--- a/src/main/java/com/nhnacademy/frontserver/auth/exception/FeignErrorDecoder.java
+++ b/src/main/java/com/nhnacademy/frontserver/auth/exception/FeignErrorDecoder.java
@@ -4,6 +4,7 @@ import com.nhnacademy.frontserver.auth.client.AuthClient;
 import com.nhnacademy.frontserver.auth.dto.TokenResponse;
 import com.nhnacademy.frontserver.auth.util.CookieUtils;
 import feign.Response;
+import feign.RetryableException;
 import feign.codec.ErrorDecoder;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -18,47 +19,58 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 public class FeignErrorDecoder implements ErrorDecoder {
 
     private final ErrorDecoder defaultDecoder = new Default();
-    private final AuthClient authClient; // 재발급 요청용
+    private final AuthClient authClient;
 
-    // 순환 참조(Bean Cycle) 방지를 위해 @Lazy 사용
     public FeignErrorDecoder(@Lazy AuthClient authClient) {
         this.authClient = authClient;
     }
 
     @Override
     public Exception decode(String methodKey, Response response) {
-        // 401 에러가 발생했는지 확인
-        if (response.status() == 401) {
-            log.info("Access Token Expired: Trying to reissue...");
+        // 로그인이나 재발급 요청 자체가 실패한 경우 -> 재시도 금지 (루프 방지)
+        if (methodKey.contains("login") || methodKey.contains("reissue")) {
+            return defaultDecoder.decode(methodKey, response);
+        }
 
-            // 현재 요청의 컨텍스트(Request/Response) 가져오기
+        if (response.status() == 401) {
+            log.info("Access Token 만료 감지. 재발급 시도 중... (Method: {})", methodKey);
+
             ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
             if (attributes != null) {
                 HttpServletRequest request = attributes.getRequest();
                 HttpServletResponse servletResponse = attributes.getResponse();
 
-                // Refresh Token 쿠키 찾기
                 String refreshToken = CookieUtils.getCookieValue(request, "refreshToken");
 
                 if (refreshToken != null) {
                     try {
-                        // Auth 서비스에 재발급 요청 (헤더로 Refresh Token 전송)
-                        // 주의: MemberAdapter에 reissue 메소드 구현 필요
+                        // 재발급 요청 (Interceptor가 /reissue 경로를 보고 Authorization 헤더 생략)
                         TokenResponse newTokens = authClient.reissue(refreshToken);
 
-                        // 성공 시 새 쿠키 굽기
+                        // 쿠키 갱신
                         if (servletResponse != null) {
                             servletResponse.addHeader("Set-Cookie",
                                     CookieUtils.createHttpOnlyCookie("accessToken", newTokens.getAccessToken(), 1800).toString());
-                            // Refresh Token도 갱신된다면 같이 굽기
+                            // Refresh Token Rotation이 있다면 이것도 갱신
+                            servletResponse.addHeader("Set-Cookie",
+                                    CookieUtils.createHttpOnlyCookie("refreshToken", newTokens.getRefreshToken(), 60 * 60 * 24 * 7).toString());
                         }
 
-                        log.info("Token Reissue Success. Please retry the request.");
-                        // todo 재발급 실패 시 예외처리
-                        return new RuntimeException();
+                        log.info("토큰 재발급 성공! 원래 요청을 다시 시도합니다.");
+
+                        // [수정 2] 원래 요청 재시도 (RetryableException 던지기)
+                        return new RetryableException(
+                                response.status(),
+                                "Token reissued",
+                                response.request().httpMethod(),
+                                0L,
+                                response.request()
+                        );
+
                     } catch (Exception e) {
-                        log.error("Reissue Failed: {}", e.getMessage());
-                        // 재발급 실패 시 로그아웃 처리 등을 위해 401 그대로 전달
+                        log.error("재발급 실패 (로그아웃 필요): {}", e.getMessage());
+                        // 재발급 실패 시 401 에러 그대로 전달 -> 로그인 페이지로 튕기게 유도
+                        return defaultDecoder.decode(methodKey, response);
                     }
                 }
             }


### PR DESCRIPTION
FeignClientConfig RequestInterceptor 수정. '/reissue' 요청 시 만료된 Access Token이 헤더에 포함되지 않도록 예외 처리 추가

FeignErrorDecoder: 로그인(login) 또는 재발급(reissue) 요청 실패 시 재시도를 차단하는 로직 추가 (무한 루프 방지)

- AuthClient/AuthController: 로그아웃 시 Interceptor가 헤더를 자동 주입하므로 불필요한 파라미터 전달 로직 제거