### PR TITLE
fix: Feign 재시도 시 새 토큰 적용

### DIFF
--- a/src/main/java/com/nhnacademy/frontserver/auth/config/FeignClientConfig.java
+++ b/src/main/java/com/nhnacademy/frontserver/auth/config/FeignClientConfig.java
@@ -1,6 +1,7 @@
 package com.nhnacademy.frontserver.auth.config;
 
 import feign.RequestInterceptor;
+import feign.Retryer;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -14,9 +15,14 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 public class FeignClientConfig {
 
     @Bean
+    public Retryer retryer() {
+        return new Retryer.Default(100L, 1000L, 2);
+    }
+
+    @Bean
     public RequestInterceptor requestInterceptor() {
         return template -> {
-            if (template.url().contains("/reissue")) {
+            if ("/api/auth/reissue".equals(template.path())) {
                 return;
             }
 

--- a/src/main/java/com/nhnacademy/frontserver/auth/exception/FeignErrorDecoder.java
+++ b/src/main/java/com/nhnacademy/frontserver/auth/exception/FeignErrorDecoder.java
@@ -58,13 +58,24 @@ public class FeignErrorDecoder implements ErrorDecoder {
 
                         log.info("토큰 재발급 성공! 원래 요청을 다시 시도합니다.");
 
-                        // [수정 2] 원래 요청 재시도 (RetryableException 던지기)
+                        feign.Request originalRequest = response.request();
+                        java.util.Map<String, java.util.Collection<String>> headers = new java.util.HashMap<>(originalRequest.headers());
+                        headers.put("Authorization", java.util.Collections.singletonList("Bearer " + newTokens.getAccessToken()));
+
+                        feign.Request newRequest = feign.Request.create(
+                                originalRequest.httpMethod(),
+                                originalRequest.url(),
+                                headers,
+                                originalRequest.body(),
+                                originalRequest.charset() != null ? originalRequest.charset() : java.nio.charset.StandardCharsets.UTF_8
+                        );
+
                         return new RetryableException(
                                 response.status(),
                                 "Token reissued",
                                 response.request().httpMethod(),
-                                0L,
-                                response.request()
+                                (Long) null,
+                                newRequest
                         );
 
                     } catch (Exception e) {


### PR DESCRIPTION
- FeignErrorDecoder: 재발급된 토큰을 헤더에 적용한 새 Request 객체로 재시도 요청 수행
- FeignClientConfig: 인터셉터 예외처리 경로 명확하게 수정